### PR TITLE
Add portfolio transaction schema

### DIFF
--- a/data-collector/prisma/migrations/20250709090533_add_portfolio_feature/migration.sql
+++ b/data-collector/prisma/migrations/20250709090533_add_portfolio_feature/migration.sql
@@ -1,0 +1,33 @@
+-- CreateEnum
+CREATE TYPE "PortfolioDirection" AS ENUM ('ENTER', 'EXIT', 'CORRECTION');
+
+-- AlterTable
+ALTER TABLE "portfolio_position"
+    DROP COLUMN "category",
+    ADD COLUMN     "wallet_address" TEXT NOT NULL,
+    ADD COLUMN     "integration_id" TEXT NOT NULL,
+    ADD COLUMN     "last_balance_sync" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "portfolio_position_wallet_address_integration_id_key" ON "portfolio_position" ("wallet_address", "integration_id");
+
+-- CreateTable
+CREATE TABLE "portfolio_transaction" (
+    "id" TEXT NOT NULL DEFAULT uuid_generate_v4(),
+    "wallet_address" TEXT NOT NULL,
+    "integration_id" TEXT NOT NULL,
+    "yield_opportunity_id" TEXT NOT NULL,
+    "direction" "PortfolioDirection" NOT NULL,
+    "amount" DECIMAL(65,30) NOT NULL,
+    "usd_value" DECIMAL(65,30),
+    "tx_hash" TEXT NOT NULL,
+    "executed_at" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "portfolio_transaction_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "portfolio_transaction_tx_hash_key" UNIQUE ("tx_hash")
+);
+
+-- CreateIndex
+CREATE INDEX "portfolio_transaction_wallet_address_idx" ON "portfolio_transaction" ("wallet_address");
+
+-- AddForeignKey
+ALTER TABLE "portfolio_transaction" ADD CONSTRAINT "portfolio_transaction_yield_opportunity_id_fkey" FOREIGN KEY ("yield_opportunity_id") REFERENCES "YieldOpportunity"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/data-collector/prisma/schema.prisma
+++ b/data-collector/prisma/schema.prisma
@@ -33,19 +33,29 @@ model YieldOpportunity {
   createdAt     DateTime @default(now()) @map("created_at")
 }
 
+enum PortfolioDirection {
+  ENTER
+  EXIT
+  CORRECTION
+}
+
 model PortfolioPosition {
   id                 String   @id @map("id")
   yieldOpportunityId String   @map("yield_opportunity_id")
   amount             Float    @map("amount")
-  category           String   @map("category")
+  walletAddress      String   @map("wallet_address")
+  integrationId      String   @map("integration_id")
   entryDate         DateTime @map("entry_date")
   lastModified      DateTime @updatedAt @map("last_modified")
+  lastBalanceSync   DateTime? @map("last_balance_sync")
   currentApy        Float    @map("current_apy")
   isActive          Boolean  @default(true) @map("is_active")
   exitTxHash        String?  @map("exit_tx_hash")
   entryTxHash       String?  @map("entry_tx_hash")
   tokenAddress      String?  @map("token_address")
   tokenSymbol       String   @map("token_symbol")
+
+  @@unique([walletAddress, integrationId])
 
   @@map("portfolio_position")
 }
@@ -62,4 +72,20 @@ model PortfolioRebalance {
   annualIncomeChange Float    @map("annual_income_change")
 
   @@map("portfolio_rebalance")
+}
+
+model PortfolioTransaction {
+  id                 String           @id @default(uuid())
+  walletAddress      String           @map("wallet_address")
+  integrationId      String           @map("integration_id")
+  yieldOpportunity   YieldOpportunity @relation(fields: [yieldOpportunityId], references: [id])
+  yieldOpportunityId String           @map("yield_opportunity_id")
+  direction          PortfolioDirection
+  amount             Decimal
+  usdValue           Decimal?         @map("usd_value")
+  txHash             String           @unique @map("tx_hash")
+  executedAt         DateTime         @map("executed_at")
+
+  @@index([walletAddress])
+  @@map("portfolio_transaction")
 }

--- a/data-collector/types.ts
+++ b/data-collector/types.ts
@@ -68,15 +68,35 @@ export interface PortfolioPosition {
   id: string;
   yieldOpportunityId: string;
   amount: number;
-  category: string;
+  walletAddress: string;
+  integrationId: string;
   entryDate: Date;
   lastModified: Date;
+  lastBalanceSync?: Date;
   currentApy: number;
   isActive: boolean;
   exitTxHash?: string;
   entryTxHash?: string;
   tokenAddress?: string;
   tokenSymbol: string;
+}
+
+export enum PortfolioDirection {
+  ENTER = 'ENTER',
+  EXIT = 'EXIT',
+  CORRECTION = 'CORRECTION',
+}
+
+export interface PortfolioTransaction {
+  id: string;
+  walletAddress: string;
+  integrationId: string;
+  yieldOpportunityId: string;
+  direction: PortfolioDirection;
+  amount: string;
+  usdValue?: string;
+  txHash: string;
+  executedAt: Date;
 }
 
 export interface PortfolioRebalance {
@@ -88,5 +108,4 @@ export interface PortfolioRebalance {
   fromApy: number;
   toApy: number;
   gasCost: number;
-  annualIncomeChange: number;
-} 
+  annualIncomeChange: number;} 


### PR DESCRIPTION
## Summary
- extend Prisma schema with `PortfolioDirection`, `PortfolioTransaction`, and new fields on `PortfolioPosition`
- add SQL migration for portfolio feature
- update TypeScript interfaces

## Testing
- `npx prisma generate` *(fails: 403 Forbidden, registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e3056e2f8832c91ba344703c90bc6