### PR TITLE
Implement portfolio API routes

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+DATABASE_URL=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Scripts
+
+- `pnpm dev`  - run the development server
+- `pnpm test` - execute unit tests with Vitest

--- a/frontend/app/api/portfolio/route.ts
+++ b/frontend/app/api/portfolio/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const runtime = 'nodejs';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const wallet = searchParams.get('wallet');
+  if (!wallet) {
+    return NextResponse.json({ error: 'wallet is required' }, { status: 400 });
+  }
+
+  const positions = await prisma.portfolioPosition.findMany({
+    where: { walletAddress: wallet, isActive: true },
+    include: { yieldOpportunity: { select: { apy: true, tvl: true } } }
+  });
+
+  const result = positions.map(p => ({
+    integrationId: p.integrationId,
+    amount: p.amount,
+    usdValue: (p as any).usdValue ?? null,
+    apy: p.yieldOpportunity.apy,
+    tvl: p.yieldOpportunity.tvl,
+    entryDate: p.entryDate,
+    lastBalanceSync: p.lastBalanceSync
+  }));
+
+  return NextResponse.json(result);
+}

--- a/frontend/app/api/portfolio/summary/route.ts
+++ b/frontend/app/api/portfolio/summary/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { Decimal } from '@prisma/client/runtime/library';
+
+export const runtime = 'nodejs';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const wallet = searchParams.get('wallet');
+  if (!wallet) {
+    return NextResponse.json({ error: 'wallet is required' }, { status: 400 });
+  }
+
+  const positions = await prisma.portfolioPosition.findMany({
+    where: { walletAddress: wallet, isActive: true },
+    include: { yieldOpportunity: { select: { apy: true } } }
+  });
+
+  let totalUsd = new Decimal(0);
+  let weightedApy = new Decimal(0);
+  let totalAmount = new Decimal(0);
+
+  for (const p of positions) {
+    const amount = new Decimal(p.amount);
+    const usdVal = new Decimal((p as any).usdValue ?? 0);
+    if (!(p as any).usdValue === null) {
+      totalUsd = totalUsd.plus(usdVal);
+    }
+    weightedApy = weightedApy.plus(amount.times(p.yieldOpportunity.apy));
+    totalAmount = totalAmount.plus(amount);
+  }
+
+  const avgApy = totalAmount.eq(0)
+    ? 0
+    : weightedApy.div(totalAmount).toNumber();
+
+  return NextResponse.json({ totalUsd: totalUsd.toNumber(), avgApy });
+}

--- a/frontend/app/api/transactions/route.ts
+++ b/frontend/app/api/transactions/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { Decimal } from '@prisma/client/runtime/library';
+import { randomUUID } from 'crypto';
+
+export const runtime = 'nodejs';
+
+const BodySchema = z.object({
+  walletAddress: z.string(),
+  integrationId: z.string(),
+  yieldOpportunityId: z.string(),
+  direction: z.enum(['ENTER', 'EXIT', 'CORRECTION']),
+  amount: z.union([z.string(), z.number()]),
+  txHash: z.string(),
+  executedAt: z.string()
+});
+
+export async function POST(request: Request) {
+  const json = await request.json();
+  const parsed = BodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.format() }, { status: 422 });
+  }
+
+  const data = parsed.data;
+  const amount = new Decimal(data.amount);
+
+  await prisma.portfolioTransaction.create({
+    data: {
+      walletAddress: data.walletAddress,
+      integrationId: data.integrationId,
+      yieldOpportunityId: data.yieldOpportunityId,
+      direction: data.direction,
+      amount,
+      usdValue: null,
+      txHash: data.txHash,
+      executedAt: new Date(data.executedAt)
+    }
+  });
+
+  const now = new Date();
+  const existing = await prisma.portfolioPosition.findUnique({
+    where: {
+      walletAddress_integrationId: {
+        walletAddress: data.walletAddress,
+        integrationId: data.integrationId
+      }
+    }
+  });
+
+  if (!existing) {
+    const opp = await prisma.yieldOpportunity.findUnique({
+      where: { id: data.yieldOpportunityId },
+      select: { tokenSymbol: true, apy: true }
+    });
+    await prisma.portfolioPosition.create({
+      data: {
+        id: randomUUID(),
+        walletAddress: data.walletAddress,
+        integrationId: data.integrationId,
+        yieldOpportunityId: data.yieldOpportunityId,
+        amount: amount.toNumber(),
+        entryDate: new Date(data.executedAt),
+        lastBalanceSync: now,
+        currentApy: opp?.apy ?? 0,
+        isActive: data.direction !== 'EXIT',
+        entryTxHash: data.txHash,
+        tokenSymbol: opp?.tokenSymbol ?? ''
+      }
+    });
+  } else {
+    let newAmount = new Decimal(existing.amount);
+    let isActive = existing.isActive;
+    if (data.direction === 'ENTER') {
+      newAmount = newAmount.plus(amount);
+      isActive = true;
+    } else if (data.direction === 'EXIT') {
+      newAmount = newAmount.minus(amount);
+      if (newAmount.lte(new Decimal('1e-18'))) {
+        isActive = false;
+      }
+    } else if (data.direction === 'CORRECTION') {
+      newAmount = amount;
+    }
+
+    await prisma.portfolioPosition.update({
+      where: {
+        walletAddress_integrationId: {
+          walletAddress: data.walletAddress,
+          integrationId: data.integrationId
+        }
+      },
+      data: {
+        amount: newAmount.toNumber(),
+        isActive,
+        lastBalanceSync: now
+      }
+    });
+  }
+
+  return NextResponse.json({ success: true }, { status: 201 });
+}

--- a/frontend/lib/prisma.ts
+++ b/frontend/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@langchain/langgraph-sdk": "^0.0.11",
@@ -33,7 +34,8 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
     "viem": "~2.23.14",
-    "wagmi": "^2.14.15"
+    "wagmi": "^2.14.15",
+    "@prisma/client": "^5.22.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -44,6 +46,8 @@
     "eslint-config-next": "15.1.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "^5.22.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/frontend/tests/api-transactions.test.ts
+++ b/frontend/tests/api-transactions.test.ts
@@ -1,0 +1,49 @@
+import { POST } from '../app/api/transactions/route';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../lib/prisma', () => {
+  const create = vi.fn();
+  const findUnique = vi.fn();
+  const positionCreate = vi.fn();
+  const positionUpdate = vi.fn();
+  const oppFind = vi.fn();
+  return {
+    prisma: {
+      portfolioTransaction: { create },
+      portfolioPosition: { findUnique, create: positionCreate, update: positionUpdate },
+      yieldOpportunity: { findUnique: oppFind }
+    }
+  };
+});
+
+const { prisma } = await import('../lib/prisma');
+
+describe('POST /api/transactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 422 on validation error', async () => {
+    const res = await POST(new Request('http://test', { method: 'POST', body: JSON.stringify({}) }));
+    expect(res.status).toBe(422);
+  });
+
+  it('creates transaction and position', async () => {
+    (prisma.portfolioPosition.findUnique as any).mockResolvedValue(null);
+    (prisma.yieldOpportunity.findUnique as any).mockResolvedValue({ tokenSymbol: 'ETH', apy: 1 });
+
+    const body = {
+      walletAddress: '0xabc',
+      integrationId: '1',
+      yieldOpportunityId: 'y1',
+      direction: 'ENTER',
+      amount: '1',
+      txHash: '0x1',
+      executedAt: new Date().toISOString()
+    };
+    const res = await POST(new Request('http://test', { method: 'POST', body: JSON.stringify(body) }));
+    expect(res.status).toBe(201);
+    expect(prisma.portfolioTransaction.create).toHaveBeenCalled();
+    expect(prisma.portfolioPosition.create).toHaveBeenCalled();
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "types": ["vitest/globals"],
     "incremental": true,
     "plugins": [
       {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['tests/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- add Prisma singleton helper for frontend
- handle transaction creation and portfolio updates
- expose portfolio and summary API routes
- provide Vitest tests and config
- document scripts and sample env

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e415f105c832c8d5cce724a4aa146