### PR TITLE
Fix multi-step transaction handling

### DIFF
--- a/apps/frontend/app/api/transactions/route.ts
+++ b/apps/frontend/app/api/transactions/route.ts
@@ -12,7 +12,9 @@ const BodySchema = z.object({
   direction: z.enum(['ENTER', 'EXIT', 'CORRECTION']),
   amount: z.union([z.string(), z.number()]),
   txHash: z.string(),
-  executedAt: z.string()
+  executedAt: z.string(),
+  token_symbol: z.string(),
+  token_address: z.string().nullable(),
 });
 
 export async function POST(request: Request) {
@@ -32,7 +34,9 @@ export async function POST(request: Request) {
       direction: data.direction,
       amount,
       txHash: data.txHash,
-      executedAt: new Date(data.executedAt)
+      executedAt: new Date(data.executedAt),
+      token_symbol: data.token_symbol,
+      token_address: data.token_address,
     }
   });
 

--- a/apps/frontend/components/investment-modal.tsx
+++ b/apps/frontend/components/investment-modal.tsx
@@ -278,29 +278,6 @@ export function InvestmentModal({
                 description: `Transaction ${i + 1}/${txs.length} has been confirmed`,
               });
 
-              await fetch('/api/transactions', {
-                method: 'POST',
-                body: JSON.stringify({
-                  walletAddress: meta.wallet,
-                  integrationId: meta.integrationId,
-                  direction: 'ENTER',
-                  amount: meta.amount,
-                  txHash: hash,
-                  executedAt: new Date().toISOString()
-                })
-              })
-
-              queryClient.setQueryData(['portfolio', meta.wallet], (old: any) =>
-                addOrUpdatePosition(old as PortfolioPosition[], {
-                  wallet_address: meta.wallet,
-                  integration_id: meta.integrationId,
-                  amount: meta.amount,
-                  usd_value: null,
-                  entry_date: new Date().toISOString(),
-                  apy: 0,
-                  last_balance_sync: new Date().toISOString()
-                })
-              )
             } else {
               throw new Error(
                 `Transaction failed with status: ${result.status}`,
@@ -327,11 +304,41 @@ export function InvestmentModal({
         }
       }
 
+      // After the loop, if all transactions were successful:
+      if (hashes.length === txs.length && hashes.length > 0) {
+        await fetch('/api/transactions', {
+          method: 'POST',
+          body: JSON.stringify({
+            walletAddress: meta.wallet,
+            integrationId: meta.integrationId,
+            txHash: hashes[hashes.length - 1],
+            direction: 'ENTER',
+            amount: meta.amount,
+            executedAt: new Date().toISOString(),
+            token_symbol: yieldOption.token_symbol,
+            token_address: yieldOption.token_address,
+          })
+        });
+
+        queryClient.setQueryData(['portfolio', meta.wallet], (old: any) =>
+          addOrUpdatePosition(old as PortfolioPosition[], {
+            wallet_address: meta.wallet,
+            integration_id: meta.integrationId,
+            yield_opportunity_id: meta.integrationId,
+            amount: meta.amount,
+            usd_value: null,
+            entry_date: new Date().toISOString(),
+            apy: 0, // APY can be updated later
+            last_balance_sync: new Date().toISOString()
+          })
+        );
+      }
+
       // All transactions completed successfully
       setIsInvesting(false);
-      return hashes;
+      return hashes; // Return all hashes as before
     },
-    [sendTransactionAsync, toast, waitForTransaction, queryClient],
+    [sendTransactionAsync, toast, waitForTransaction, queryClient, yieldOption.token_symbol, yieldOption.token_address],
   );
 
   // Handle chain switching


### PR DESCRIPTION
## Summary
- update frontend transaction processing to send only the last tx hash
- include token details in API payload and clean request body
- update API schema and Prisma create call for token fields

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb550d580832c9ab0a8d839b177ab